### PR TITLE
Fix tab navigation and script paths

### DIFF
--- a/index-completo.html
+++ b/index-completo.html
@@ -914,11 +914,10 @@ body {
     </div>
 
     <!-- SCRIPTS MODULARES -->
-    <script src="assets/js/data-tables.js"></script>
-    <script src="assets/js/calculations.js"></script>
-    <script src="assets/js/validations.js"></script>
-    <script src="assets/js/ui-manager.js"></script>
-    <script src="assets/js/app.js"></script>
+    <script src="data-tables.js"></script>
+    <script src="calculations.js"></script>
+    <script src="validations.js"></script>
+    <script src="ui-manager.js"></script>
 </body>
 </html>
 

--- a/ui-manager.js
+++ b/ui-manager.js
@@ -49,7 +49,7 @@ function switchTab(tabName) {
         }
 
         // Activar el botón de la pestaña
-        const selectedButton = document.querySelector(`[onclick="switchTab('${tabName}')"]`);
+        const selectedButton = document.querySelector(`.tab[data-tab="${tabName}"]`);
         if (selectedButton) {
             selectedButton.classList.add('active');
         }
@@ -77,7 +77,7 @@ function actualizarIndicadoresPestanas() {
         const pestanas = ['proyecto', 'caida-tension', 'cortocircuito', 'resultados'];
         
         pestanas.forEach(pestana => {
-            const botonPestana = document.querySelector(`[onclick="switchTab('${pestana}')"]`);
+            const botonPestana = document.querySelector(`.tab[data-tab="${pestana}"]`);
             if (!botonPestana) return;
 
             // Remover clases de estado previas
@@ -666,4 +666,20 @@ window.actualizarElementoResultado = actualizarElementoResultado;
 window.toggleElementos = toggleElementos;
 window.toggleElemento = toggleElemento;
 window.obtenerDatosFormularios = obtenerDatosFormularios;
+
+// Inicializar manejadores de pestañas al cargar la página
+document.addEventListener('DOMContentLoaded', () => {
+    const tabButtons = document.querySelectorAll('.tabs-container .tab');
+    tabButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const tabName = btn.dataset.tab;
+            if (tabName) {
+                switchTab(tabName);
+            }
+        });
+    });
+
+    // Mostrar la pestaña inicial
+    switchTab(appState.pestanaActiva);
+});
 


### PR DESCRIPTION
## Summary
- connect UI tabs using data attributes instead of relying on `onclick`
- hook up tab buttons on DOM load
- update HTML to load JS files from repo root instead of nonexistent `assets/js`

## Testing
- `node --check ui-manager.js`
- `node --check calculations.js`
- `node --check validations.js`
- `node --check data-tables.js`

------
https://chatgpt.com/codex/tasks/task_e_6883c4adf0a4832c9e95d04d0f4c2c15